### PR TITLE
feat: init repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Ignore build and output artifacts
+output/
+keys/teamspeak-bootc-admin*
+*.iso
+*.key
+*.key.pub
+*.log
+*.tmp
+*.bak
+__pycache__/
+*.pyc
+# Ignore editor and OS files
+.vscode/
+*.swp
+.DS_Store

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,76 @@
+# Fedora Bootable Container for TeamSpeak Server
+FROM quay.io/fedora/fedora-bootc:43
+
+ARG TS3_VERSION=3.13.7
+
+# Install packages, setup TeamSpeak, and configure system in one layer
+WORKDIR /opt
+RUN dnf update -y && \
+    dnf install -y \
+    wget \
+    tar \
+    bzip2 \
+    sqlite \
+    glibc.i686 \
+    libstdc++.i686 \
+    systemd \
+    sudo \
+    openssh-server \
+    qemu-guest-agent \
+    cloud-init \
+    firewalld \
+    audit \
+    && dnf clean all \
+    && printf '%s\n' \
+    '# TeamSpeak Server System User' \
+    'u teamspeak - "TeamSpeak Server" /var/lib/teamspeak /sbin/nologin' \
+    > /usr/lib/sysusers.d/99-teamspeak.conf \
+    && wget https://files.teamspeak-services.com/releases/server/${TS3_VERSION}/teamspeak3-server_linux_amd64-${TS3_VERSION}.tar.bz2 \
+    && tar -xjf teamspeak3-server_linux_amd64-${TS3_VERSION}.tar.bz2 \
+    && mv teamspeak3-server_linux_amd64 teamspeak3-server \
+    && rm teamspeak3-server_linux_amd64-3.13.7.tar.bz2 \
+    && touch /opt/teamspeak3-server/.ts3server_license_accepted
+
+# Create systemd service file for TeamSpeak
+COPY config/teamspeak.service /etc/systemd/system/teamspeak.service
+
+# Create directories, configure tmpfiles, enable services, and configure SSH in one layer
+RUN systemctl enable teamspeak.service \
+    && mkdir -p /etc/teamspeak \
+    && mkdir -p /var/lib/teamspeak/{logs,files,database} \
+    && mkdir -p /opt/teamspeak3-server/{logs,files,database} \
+    && mkdir -p /usr/lib/tmpfiles.d \
+    && printf '%s\n' \
+    '# TeamSpeak Server Directory Ownership' \
+    'z /opt/teamspeak3-server 0755 teamspeak teamspeak -' \
+    'Z /opt/teamspeak3-server 0755 teamspeak teamspeak -' \
+    'z /var/lib/teamspeak 0755 teamspeak teamspeak -' \
+    'Z /var/lib/teamspeak 0755 teamspeak teamspeak -' \
+    'z /etc/teamspeak 0755 teamspeak teamspeak -' \
+    'd /var/lib/teamspeak/database 0755 teamspeak teamspeak -' \
+    'd /var/lib/teamspeak/logs 0755 teamspeak teamspeak -' \
+    'd /var/lib/teamspeak/files 0755 teamspeak teamspeak -' \
+    > /usr/lib/tmpfiles.d/99-teamspeak.conf \
+    && sed -i 's/^SELINUX=.*/SELINUX=disabled/' /etc/selinux/config \
+    && systemctl enable sshd \
+    && systemctl enable qemu-guest-agent \
+    && systemctl enable firewalld \
+    && mkdir -p /etc/ssh/sshd_config.d \
+    && printf '%s\n' \
+    'PermitRootLogin no' \
+    'PasswordAuthentication yes' \
+    'PubkeyAuthentication yes' \
+    'AuthorizedKeysFile .ssh/authorized_keys' \
+    > /etc/ssh/sshd_config.d/99-bootc.conf
+
+# Copy custom configuration if provided
+COPY config/ /etc/teamspeak/
+
+# Expose TeamSpeak ports
+EXPOSE 9987/udp 10011 30033
+
+# Set up bootc to use systemd as init
+WORKDIR /opt/teamspeak3-server
+
+# Use systemd as PID 1 for proper bootc behavior
+CMD ["/sbin/init"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,194 @@
-# bootc-teamspeak
-Containerfile, services, and helper scripts to create a bootable ISO to run a Teamspeak server
+# TeamSpeak 3 Server on Fedora Bootc
+
+A bootable container deployment of TeamSpeak 3 Server using [Fedora bootc](https://docs.fedoraproject.org/en-US/bootc/) technology with automated Anaconda kickstart installation.
+
+The overarching goal to this project is to deliver an ISO which can be utilized to rapidly deploy a Teamspeak server as a deployable self-configuring ISO and for myself to learn the basics of bootable containers.
+
+**Note**: This project is currently under development, feel free to contribute or take inspiration.
+
+## 🚀 Quick Start
+
+```bash
+# Generate keys and set passwords
+./teamspeak-bootc.sh genkey
+
+# Build the container image
+./teamspeak-bootc.sh build
+
+# Create bootable ISO with automated installation
+./teamspeak-bootc.sh deploy
+
+# Deploy to Proxmox (upload output/install.iso)
+# Boot VM - installation proceeds automatically
+# Access via SSH: ssh fedora@<vm-ip> (password: password)
+```
+
+### Build Process
+
+1. **Generate Keys & Passwords**: Creates SSH keys and sets initial passwords
+
+    ```bash
+    ./teamspeak-bootc.sh genkey
+    ```
+
+2. **Build Container Image**: Packages TeamSpeak server and dependencies into a bootc container
+
+    ```bash
+    ./teamspeak-bootc.sh build
+    ```
+
+    - Builds from `Containerfile`
+    - Installs TeamSpeak 3.13.7
+    - Configures systemd services from `config/teamspeak.service`
+    - Creates required directories
+    - Copies `config` to `/etc/teamspeak`, important for `ts3server.ini`
+
+### Deployment Process
+
+1. **Create Bootable ISO**: Generates installation media with kickstart automation
+
+    ```bash
+    ./teamspeak-bootc.sh deploy
+    ```
+
+    - Creates `output/install.iso` using Anaconda installer
+    - Embeds bootc container image
+    - Configures unattended installation
+
+2. **Deploy on Hardware/VM**: Boot target system from the ISO
+
+    - Installation proceeds automatically
+    - System configures itself with TeamSpeak server
+    - TeamSpeak service starts automatically on first boot
+    - Admin token available in `/var/lib/teamspeak/logs/` (see ts3server_*.log)
+
+## 📋 Features
+
+- **Automated Installation**: [Anaconda kickstart](https://osbuild.org/docs/bootc/#anaconda-iso-installer-options-installer-mapping) for unattended deployment
+- **Immutable Infrastructure**: [Bootc](https://github.com/containers/bootc) container with systemd as PID 1
+- **Persistent Data**: TeamSpeak data in `/var/lib/teamspeak` (survives updates)
+- **User Injection**: SSH keys and credentials via [bootc build config](https://osbuild.org/docs/bootc/#-build-config)
+- **Security**: Hardened systemd service with proper isolation
+- **Update Support**: In-place updates via `bootc switch`
+
+## 🏗️ Architecture
+
+This is the target directory structure for the Bootc container image:
+
+```shell
+┌─────────────────────────────────────────────────────────────────┐
+│                    Bootc Container Image                        │
+│ ┌─────────────────────────────────────────────────────────────┐ │
+│ │ /opt/teamspeak3-server/ (READ-ONLY)                         │ │
+│ │ ├── ts3server (binary)                                      │ │
+│ │ ├── sql/create_sqlite/ (database schemas)                   │ │
+│ │ └── logs/, files/, database/ (read-only, static content)    │ │
+│ └─────────────────────────────────────────────────────────────┘ │
+│ ┌─────────────────────────────────────────────────────────────┐ │
+│ │ /var/lib/teamspeak/ (PERSISTENT, writable)                  │ │
+│ │ ├── logs/ (actual log storage, writable)                    │ │
+│ │ ├── files/ (file transfers, writable)                       │ │
+│ │ └── database/ts3server.sqlitedb (SQLite database, writable) │ │
+│ └─────────────────────────────────────────────────────────-───┘ │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## 🛠️ Management Commands
+
+All commands use the unified management script:
+
+```bash
+# Build container image
+./teamspeak-bootc.sh build
+
+# Create bootable ISO with kickstart
+./teamspeak-bootc.sh deploy
+
+# Clean up old images
+./teamspeak-bootc.sh clean
+```
+
+## 📝 Configuration Files
+
+### `config/config.toml`
+
+[Bootc build config](https://osbuild.org/docs/bootc/#-build-config) with:
+
+- User creation via kickstart
+- SSH key injection
+- Automated installation settings
+- Filesystem customizations
+
+### `Containerfile`
+
+Clean bootc container with:
+
+- TeamSpeak 3.13.7 installation
+- systemd-sysusers for service account
+- tmpfiles.d for directory ownership
+- `/sbin/init` as PID 1 (proper bootc pattern)
+
+### `config/teamspeak.service`
+
+Systemd service with direct writable directories for persistent data and security hardening.
+
+## 🔧 Deployment Steps
+
+1. **Generate Keys/Set Password**: `./teamspeak-bootc.sh genkey`
+1. **Build**: `./teamspeak-bootc.sh build`
+1. **Create ISO**: `./teamspeak-bootc.sh deploy`
+1. **Upload**: Transfer `output/install.iso` to Proxmox ISO storage
+1. **Create VM**: 4GB+ RAM, 20GB+ disk, attach ISO as CD/DVD
+1. **Boot**: Installation proceeds automatically (no interaction needed)
+1. **Access**: SSH `fedora@<vm-ip>` (password: `password`)
+1. **Verify**: `sudo systemctl status teamspeak`
+
+TeamSpeak admin token appears in `/var/lib/teamspeak/logs/ts3server_*.log` on first start.
+
+```bash
+VM_ID=103
+qm create $VM_ID --name teamspeak --machine q35 --bios ovmf --scsi0 local-lvm:103,iothreaad=on --efidisk0 local-lvm:1,efitype=4m,pre-enrolled-keys=1 --memory 4096 --cores 4 --net0 virtio,bridge=vmbr0 --cdrom local:iso/$ISO_FILE
+```
+
+## 🔌 Proxmox VM Creation
+
+For Proxmox deployment, you can use this command to create a suitable VM:
+
+```bash
+VM_ID=103
+# Create TeamSpeak VM with UEFI, 4GB RAM, and 4 cores
+qm create $VM_ID \
+    --name "teamspeak" \
+    --machine q35 \
+    --bios ovmf \
+    --efidisk0 local-lvm:1,efitype=4m,pre-enrolled-keys=1 \
+    --scsihw virtio-scsi-single \
+    --scsi0 local-lvm:20,iothread=on \
+    --memory 4096 \
+    --cores 4 \
+    --net0 virtio,bridge=vmbr0 \
+    --bootdisk scsi0 \
+    --serial0 socket \
+    --vga std \
+    --cdrom local:iso/install.iso
+```
+
+This creates a VM with UEFI boot, virtio-scsi disk, and network connectivity. After creation, start the VM and the automated installation will begin.
+```
+
+
+## 🧹 File Structure
+
+```text
+teamspeak/
+├── Containerfile                   # Bootc container definition
+├── teamspeak-bootc.sh              # Management script
+├── config/
+│   ├── config.toml                 # Build config with kickstart
+│   ├── teamspeak.service           # Systemd service
+│   └── ts3server.ini               # TeamSpeak configuration
+└── keys/
+    ├── README.md
+    ├── teamspeak-bootc-key
+    └── teamspeak-bootc-key.pub
+```

--- a/config/config.toml
+++ b/config/config.toml
@@ -1,0 +1,52 @@
+# TeamSpeak Bootc Image Build Configuration
+# This config uses Anaconda kickstart for automated ISO installation
+# User configuration is handled in the kickstart script below
+
+# Anaconda kickstart configuration for automated installation
+[customizations.installer.kickstart]
+contents = """
+# Automated TeamSpeak Bootc Installation
+user --name=fedora --password=password --groups=wheel --homedir=/var/home/fedora --shell=/bin/bash
+sshkey --username=fedora "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA1KEXIhsrOp8nwvFY2FfCciJa2zOAQ+xSqay/41GN8j teamspeak-bootc-admin"
+text --non-interactive
+lang en_US.UTF-8
+keyboard us
+timezone America/New_York --utc
+
+# Network configuration
+network --bootproto=dhcp --device=link --activate --onboot=on --hostname=teamspeak-server
+
+# Storage configuration - use first available disk
+ignoredisk --only-use=sda
+bootloader --location=boot --boot-drive=sda
+zerombr
+clearpart --all --initlabel --disklabel=gpt --drives=sda
+
+# Create partitions
+part /boot/efi --fstype=efi --size=512 --ondisk=sda
+part /boot --fstype=ext4 --size=1024 --ondisk=sda
+part pv.01 --size=1 --grow --ondisk=sda
+
+# LVM configuration
+volgroup system pv.01
+logvol / --vgname=system --name=root --size=8192 --grow --fstype=ext4
+logvol swap --vgname=system --name=swap --size=2048
+
+# Root password (will be disabled in favor of user account)
+rootpw --lock
+
+# User account configuration with SSH key
+
+# Services and basic firewall
+services --enabled=sshd,qemu-guest-agent,teamspeak
+firewall --enabled --service=ssh
+firewall --port=9987:udp,10011:tcp,30033:tcp
+
+# Complete installation and reboot
+reboot --eject
+"""
+
+# Filesystem customizations
+[[customizations.filesystem]]
+mountpoint = "/var/lib/teamspeak"
+minsize = "10 GiB"

--- a/config/teamspeak.service
+++ b/config/teamspeak.service
@@ -1,0 +1,47 @@
+[Unit]
+Description=TeamSpeak 3 Server
+After=network.target systemd-tmpfiles-setup.service systemd-sysusers.service
+Wants=systemd-tmpfiles-setup.service systemd-sysusers.service
+
+[Service]
+Type=simple
+User=teamspeak
+Group=teamspeak
+WorkingDirectory=/opt/teamspeak3-server
+PermissionsStartOnly=yes
+
+# Ensure directories exist with correct permissions before starting
+ExecStartPre=/bin/mkdir -p /var/lib/teamspeak/database /var/lib/teamspeak/logs /var/lib/teamspeak/files
+ExecStartPre=/bin/chown -Rf teamspeak:teamspeak /var/lib/teamspeak/database /var/lib/teamspeak/logs /var/lib/teamspeak/files
+
+## All writable data is stored directly in /var/lib/teamspeak. BindPaths removed for Bootc compatibility.
+
+# Security hardening (optimized for bootc)
+PrivateDevices=yes
+ProtectSystem=strict
+ProtectHome=yes
+NoNewPrivileges=yes
+# Allow writes to persistent data dir and temp dir used by SQLite
+ReadWritePaths=/var/lib/teamspeak
+ReadWritePaths=/var/tmp
+Environment=SQLITE_TMPDIR=/var/tmp
+LimitNOFILE=65536
+
+Environment=TMPDIR=/var/tmp
+ExecStart=/opt/teamspeak3-server/ts3server \
+	inifile=/etc/teamspeak/ts3server.ini \
+	logpath=/var/lib/teamspeak/logs/ \
+	dbplugin=ts3db_sqlite3 \
+	dbpluginparameter=/var/lib/teamspeak/database/ts3server.sqlitedb \
+	dbsqlcreatepath=/opt/teamspeak3-server/sql/create_sqlite/ \
+	dbsqlpath=/opt/teamspeak3-server/sql/
+ExecStop=/bin/kill -TERM $MAINPID
+StandardOutput=journal
+StandardError=journal
+
+# Restart configuration
+RestartSec=5
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/config/ts3server.ini
+++ b/config/ts3server.ini
@@ -1,0 +1,117 @@
+# TeamSpeak 3 Server Configuration
+# This file contains the configuration for the TeamSpeak server
+
+# Server settings
+default_voice_port=9987
+voice_ip=0.0.0.0
+filetransfer_port=30033
+filetransfer_ip=0.0.0.0
+query_port=10011
+query_ip=0.0.0.0
+
+dbplugin=ts3db_sqlite3
+dbpluginparameter=/var/lib/teamspeak/database/ts3server.sqlitedb
+dbsqlcreatepath=/opt/teamspeak3-server/sql/create_sqlite/
+dbsqlpath=/opt/teamspeak3-server/sql/
+
+logpath=/var/lib/teamspeak/logs/
+filetransferpath=/var/lib/teamspeak/files/
+logquerycommands=1
+dblogkeepdays=90
+logappend=0
+
+# License
+license_accepted=1
+
+# PID file location - place under persistent /var/lib/teamspeak via absolute path
+pidfile=/var/lib/teamspeak/ts3server.pid
+
+# Machine ID
+machine_id=
+
+
+# Server Networking Settings
+#serveradmin_password=        # Password for the server admin account (strongly recommended to set)
+#query_skipbruteforcecheck=0  # Set to 1 to disable brute force protection for server queries
+#query_buffer_mb=20           # Memory allocated for the query buffer in MB
+#query_ip_allowlist=          # File containing allowed IP addresses for server query
+#query_ip_denylist=           # File containing denied IP addresses for server query
+#query_ssh_ip=0.0.0.0         # IP for SSH server query
+#query_ssh_port=10022         # Port for SSH server query
+#query_protocols=raw,ssh      # Enabled query protocols (raw,ssh,http)
+#query_timeout=300            # Timeout for server queries in seconds
+#query_http_ip=0.0.0.0        # IP for HTTP query
+#query_http_port=10080        # Port for HTTP query
+
+# Voice Settings
+#nickname=TeamSpeakServer     # Default server nickname
+#default_server_group=8       # Default server group ID
+#default_channel_group=8      # Default channel group ID
+#default_channel_admin_group=5 # Default channel admin group ID
+#min_client_version=          # Minimum client version required to connect
+#min_android_version=         # Minimum Android client version required
+#min_ios_version=             # Minimum iOS client version required
+#min_mac_version=             # Minimum Mac client version required
+#min_windows_version=         # Minimum Windows client version required
+#codec_voice_quality=4        # Voice quality (1-10)
+#channel_empty_time=0         # Time until empty channels are deleted (0=never)
+#welcomemessage=Welcome to TeamSpeak! # Welcome message shown to clients on connect
+#hostmessage=                 # Host message
+#hostmessage_mode=0           # Host message mode (0=none, 1=log, 2=modal, 3=modalquit)
+#download_quota=0             # Download quota in bytes
+#upload_quota=0               # Upload quota in bytes
+#max_download_total_bandwidth=0 # Maximum download bandwidth (bytes/second)
+#max_upload_total_bandwidth=0   # Maximum upload bandwidth (bytes/second)
+#enable_youtube_webscript=0   # Enable YouTube player (0=disabled, 1=enabled)
+
+# Security Settings
+#needed_identity_security_level=8 # Required security level for client identities
+#weblist_enabled=1            # Allow server to be shown on the public server list
+#weblist_secret_key=          # Secret key for weblist
+#enable_reporting=1           # Enable crash reporting
+#allowlist_mode=0             # Allowlist mode (0=disabled, 1=enabled)
+#allowlist_file=allowlist.txt # File containing allowed IP addresses
+#denylist_mode=0              # Denylist mode (0=disabled, 1=enabled)
+#denylist_file=denylist.txt   # File containing denied IP addresses
+#anti_flood_points_needed_command_block=150 # Anti-flood protection threshold for commands
+#anti_flood_points_needed_ip_block=250      # Anti-flood protection threshold for IP blocks
+#anti_flood_points_tick_reduce=5            # Anti-flood points reduction per tick
+#enable_ban_checks=1          # Enable ban checks
+#enable_server_update_checks=1 # Enable server update checks
+#enable_tts=0                 # Enable text to speech
+
+# Performance Settings
+#threads_databasequery=2      # Database query threads
+#serverinstance_database_connections_total=2 # Total database connections
+#serverinstance_filetransfer_port=30033 # File transfer port
+#serverinstance_max_download_total_bandwidth=18446744073709551615 # Max download bandwidth
+#serverinstance_max_upload_total_bandwidth=18446744073709551615   # Max upload bandwidth
+#server_max_client_connects=10 # Maximum simultaneous connection attempts
+#max_clients=32               # Maximum number of clients allowed
+#reserved_slots=0             # Number of reserved slots
+#enable_ts3menuicon=0         # Enable TeamSpeak tray icon
+
+# Advanced Settings
+#tempchannels_needed_subscribe_power=0 # Power needed to subscribe to temp channels
+#tempchannels_needed_join_power=0       # Power needed to join temp channels
+#tempchannels_needed_delete_power=0     # Power needed to delete temp channels
+#tempchannels_password_needed_join_power=0 # Power needed to join password protected temp channels
+#tempchannels_password_needed_delete_power=0 # Power needed to delete password protected temp channels
+#clear_database=0             # Clear database on startup (DANGER: deletes all data!)
+#online_client_list_poll_interval=0   # Client list poll interval
+#force_client_nickname_change=0       # Force client nickname change if taken
+#client_mandatory_security_level=0    # Mandatory client security level
+#temporary_channel_delete_delay=0     # Delay for deleting temporary channels in seconds
+#disable_msghistory=0                 # Disable message history
+
+# TSDNS Settings
+#tsdns_port=41144             # TSDNS server port
+#tsdns_ip=0.0.0.0             # TSDNS server IP
+#tsdns_server_file=tsdns_settings.ini # TSDNS server settings file
+
+# Backup Settings
+#create_default_virtualserver=1 # Create default virtual server on first start
+#crashdump_path=/var/lib/teamspeak/crashdumps/ # Path for crash dumps
+#backup_path=/var/lib/teamspeak/backups/       # Path for server backups
+#backup_interval=14400        # Backup interval in seconds (14400 = 4 hours)
+#backup_delete_oldest=0       # Delete oldest backup when limit is reached

--- a/keys/README.md
+++ b/keys/README.md
@@ -1,0 +1,54 @@
+# SSH Key Management for TeamSpeak Bootc
+
+## Generated SSH Keys
+
+This directory contains the SSH key pair for accessing the TeamSpeak Bootc VM:
+
+- `teamspeak-bootc-admin` - Private key (keep secure)
+- `teamspeak-bootc-admin.pub` - Public key (embedded in the container image)
+
+## Usage
+
+### SSH Access to VM
+
+```bash
+# SSH using the private key
+ssh -i keys/teamspeak-bootc-admin fedora@<vm-ip>
+
+# Or add the key to your SSH agent
+ssh-add keys/teamspeak-bootc-admin
+ssh fedora@<vm-ip>
+```
+
+### Key Information
+
+- **Key Type**: Ed25519 (modern, secure)
+- **Comment**: teamspeak-bootc-admin
+- **User**: fedora (with sudo access via wheel group)
+
+## Security Notes
+
+- The private key should be kept secure and not shared
+- The public key is embedded in the container image during build
+- Both password and key-based authentication are enabled for flexibility
+- Default password is "password" (change in production)
+
+## Regenerating Keys and Injecting into Kickstart
+
+To generate a new SSH key pair and automatically inject the credentials into your kickstart config:
+
+```bash
+# Run the management script
+./teamspeak-bootc.sh genkey
+```
+
+### This command will
+
+- Generate a new key pair in the keys/ directory
+- Prompt for username and password
+- Automatically update config/config.toml with the new user and public key
+- You can then build and deploy your image as usual
+
+No manual editing of the Containerfile or config is required—the script handles key placement and password injection for you.
+
+**Note**: The password is only encoded in the kickstart config and not encrypted.

--- a/teamspeak-bootc.sh
+++ b/teamspeak-bootc.sh
@@ -1,0 +1,305 @@
+#!/bin/bash
+
+# TeamSpeak Bootc Management Script
+# All-in-one script for building, deploying, updating, and debugging TeamSpeak bootc containers
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$SCRIPT_DIR"
+IMAGE_NAME="localhost/teamspeak-bootc"
+CONFIG_FILE="$PROJECT_DIR/config/config.toml"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Logging functions
+log_info() { echo -e "${BLUE}ℹ️  $1${NC}"; }
+log_success() { echo -e "${GREEN}✅ $1${NC}"; }
+log_warning() { echo -e "${YELLOW}⚠️  $1${NC}"; }
+log_error() { echo -e "${RED}❌ $1${NC}"; }
+
+show_usage() {
+    cat << EOF
+TeamSpeak Bootc Management Script
+
+USAGE:
+    $0 <command> [options]
+
+COMMANDS:
+    build           Build the bootc container image
+    deploy          Create bootc disk image for deployment
+    clean           Remove old images and clean up
+    help            Show this help message
+
+EXAMPLES:
+    $0 build                    # Build container image
+    $0 deploy                   # Create .qcow2 disk image
+    $0 clean                    # Clean up old images
+
+    $0 genkey                   # Generate SSH key pair and kickstart lines
+
+EOF
+}
+
+# Validation function
+
+validate_configuration() {
+    log_info "Validating TeamSpeak bootc configuration..."
+    local errors=0
+    
+    # 1. Validate project directory structure
+    log_info "Checking directory structure..."
+    if [[ ! -f "$PROJECT_DIR/Containerfile" ]] || [[ ! -f "$PROJECT_DIR/config/teamspeak.service" ]]; then
+        log_error "Not in TeamSpeak project directory or missing required files"
+        log_info "Expected files: Containerfile, config/teamspeak.service"
+        ((errors++))
+    else
+        log_success "Directory structure validated"
+    fi
+    
+    # 2. Validate required configuration files
+    log_info "Checking configuration files..."
+    local files=(
+        "$PROJECT_DIR/config/ts3server.ini"
+        "$CONFIG_FILE"
+        "$PROJECT_DIR/config/teamspeak.service"
+        "$PROJECT_DIR/Containerfile"
+        "$PROJECT_DIR/config/config.toml"
+    )
+    
+    for file in "${files[@]}"; do
+        if [[ ! -f "$file" ]]; then
+            log_error "Required file not found: $file"
+            ((errors++))
+        else
+            log_success "Found: $(basename "$file")"
+        fi
+    done
+    
+    # 3. Validate service configuration
+    log_info "Validating service file settings..."
+    if ! grep -q "ReadWritePaths=/var/lib/teamspeak" "$PROJECT_DIR/config/teamspeak.service"; then
+        log_error "Missing ReadWritePaths=/var/lib/teamspeak"
+        ((errors++))
+    fi
+    
+    # 4. Validate SSH keys if referenced in config
+    log_info "Checking SSH key configuration..."
+    if [[ -f "$CONFIG_FILE" ]] && grep -q "sshkey" "$CONFIG_FILE" 2>/dev/null; then
+        if [[ -d "$PROJECT_DIR/keys" ]]; then
+            if ! ls "$PROJECT_DIR/keys"/*.pub >/dev/null 2>&1; then
+                log_warning "SSH public key files referenced but not found in keys directory"
+                ((errors++))
+            else
+                log_success "SSH public key files found"
+            fi
+        else
+            log_warning "SSH keys referenced in config but keys directory not found"
+            ((errors++))
+        fi
+    fi
+    
+    # 5. Return validation results
+    if [[ $errors -eq 0 ]]; then
+        log_success "All configuration validated successfully"
+        return 0
+    else
+        log_error "Configuration validation failed with $errors errors"
+        return 1
+    fi
+}
+
+# Build function
+cmd_build() {
+    log_info "Building TeamSpeak bootc container..."
+
+    validate_configuration
+
+    cd "$PROJECT_DIR"
+
+    log_info "Building $IMAGE_NAME..."
+    if sudo podman build -t "$IMAGE_NAME" . ; then
+        log_success "Image built successfully"
+    else
+        log_error "Image build failed"
+        return 1
+    fi
+
+    # Validate built image
+    log_info "Validating built image..."
+
+    if sudo podman run --rm "$IMAGE_NAME" test -f /opt/teamspeak3-server/ts3server; then
+        log_success "TeamSpeak binary exists"
+    else
+        log_error "TeamSpeak binary missing"
+        return 1
+    fi
+
+    if sudo podman run --rm "$IMAGE_NAME" test -f /opt/teamspeak3-server/sql/create_sqlite/create_tables.sql; then
+        log_success "SQL schema files exist"
+    else
+        log_error "SQL schema files missing - database initialization will fail"
+        return 1
+    fi
+
+    log_success "Build completed successfully!"
+    log_info "Next step: Run '$0 deploy' to create bootc disk image"
+}
+
+# Deploy function
+cmd_deploy() {
+    log_info "Creating bootc ISO image for deployment..."
+
+    if ! sudo podman image exists "$IMAGE_NAME"; then
+        log_error "Image $IMAGE_NAME not found. Run '$0 build' first."
+        return 1
+    fi
+
+    # Validate config.toml exists
+    if [[ ! -f "$CONFIG_FILE" ]]; then
+        log_error "config/config.toml not found. This file is required for user injection."
+        return 1
+    fi
+
+    log_info "Validating bootc configuration..."
+    if grep -q "customizations.installer.kickstart" "$CONFIG_FILE"; then
+        log_success "Kickstart configuration validated"
+    else
+        log_error "config/config.toml missing required kickstart section"
+        return 1
+    fi
+
+    mkdir -p "$PROJECT_DIR/output"
+
+    log_info "Creating bootc ISO image (this may take several minutes)..."
+    if sudo podman run --memory 24g --rm -it --privileged --pull=newer \
+         -v "$CONFIG_FILE:/config.toml:ro" \
+         -v "$PROJECT_DIR/output:/output" \
+         -v /var/lib/containers/storage:/var/lib/containers/storage \
+         quay.io/centos-bootc/bootc-image-builder:latest \
+         --rootfs ext4 \
+         --type anaconda-iso "$IMAGE_NAME"; then
+
+        log_success "Bootc ISO image created successfully!"
+        log_info "ISO image location: $PROJECT_DIR/output/install.iso"
+
+        echo
+        log_info "DEPLOYMENT STEPS (AUTOMATED KICKSTART INSTALLATION):"
+        echo "1. Upload install.iso to Proxmox ISO storage"
+        echo "2. Create new VM with at least 4GB RAM and 20GB disk"
+        echo "3. Attach the ISO as CD/DVD and set as boot device"
+        echo "4. Boot VM - installation will proceed automatically (no interaction needed)"
+        echo "5. After auto-reboot: ssh fedora@<vm-ip> (password: password)"
+        echo "6. TeamSpeak will be running automatically: sudo systemctl status teamspeak"
+        echo "7. TeamSpeak server admin token will be in: /opt/teamspeak3-server/logs/ts3server_*.log"
+
+    else
+        log_error "Failed to create bootc disk image"
+        return 1
+    fi
+}
+
+# Clean function
+cmd_clean() {
+    log_info "Cleaning up old images and containers..."
+
+    # Remove old TeamSpeak images
+    if sudo podman images | grep -q teamspeak; then
+        sudo podman rmi $(sudo podman images | grep teamspeak | awk '{print $3}') 2>/dev/null || true
+        log_success "Removed old TeamSpeak images"
+    fi
+
+    # Clean up build cache
+    sudo podman system prune -f
+
+    # Clean output directory
+    if [[ -d "$PROJECT_DIR/output" ]]; then
+        rm -rf "$PROJECT_DIR/output"
+        log_success "Cleaned output directory"
+    fi
+
+    log_success "Cleanup completed"
+}
+
+# Generate SSH key pair and output kickstart lines
+cmd_genkey() {
+    log_info "Generating SSH key pair for kickstart injection..."
+    local key_dir="$PROJECT_DIR/keys"
+    local key_name="teamspeak-bootc-admin"
+    mkdir -p "$key_dir"
+    local privkey="$key_dir/$key_name"
+    local pubkey="$key_dir/$key_name.pub"
+    if [[ -f "$privkey" || -f "$pubkey" ]]; then
+        log_warning "Key files already exist: $privkey, $pubkey"
+        read -p "Overwrite existing keys? [y/N]: " confirm
+        if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+            log_info "Aborting key generation."
+            return 0
+        fi
+        rm -f "$privkey" "$pubkey"
+    fi
+    ssh-keygen -t ed25519 -f "$privkey" -N "" -C "teamspeak-bootc-admin"
+    log_success "SSH key pair generated: $privkey, $pubkey"
+    local pubkey_content
+    pubkey_content=$(cat "$pubkey")
+    echo
+    read -s -p "Enter password for kickstart user [default: password]: " userpw
+    userpw=${userpw:-password}
+    echo
+    read -p "Enter username for kickstart user [default: fedora]: " username
+    username=${username:-fedora}
+    echo
+    log_info "Injecting user and sshkey lines into config.toml kickstart section..."
+    local config_file="$CONFIG_FILE"
+    local kickstart_marker="# Automated TeamSpeak Bootc Installation"
+    local user_line="user --name=$username --password=$userpw --groups=wheel --homedir=/var/home/$username --shell=/bin/bash"
+    local sshkey_line="sshkey --username=$username \"$pubkey_content\""
+    if grep -q "$kickstart_marker" "$config_file"; then
+        # Remove all previous user/sshkey lines and insert new ones after the marker
+        sed "/^user --name=/d;/^sshkey --username=/d" "$config_file" | \
+        awk -v u="$user_line" -v k="$sshkey_line" -v m="$kickstart_marker" '
+            { print }
+            $0 ~ m { print u; print k }
+        ' > "$config_file.tmp" && mv "$config_file.tmp" "$config_file"
+        log_success "Kickstart admin user and sshkey injected into config.toml."
+    else
+        log_error "Kickstart marker not found in config.toml. Please add manually."
+        echo "$user_line"
+        echo "$sshkey_line"
+    fi
+    log_success "Done."
+}
+
+# Main function
+main() {
+    case "${1:-help}" in
+        build)
+            cmd_build
+            ;;
+        deploy)
+            cmd_deploy
+            ;;
+        clean)
+            cmd_clean
+            ;;
+        genkey)
+            cmd_genkey
+            ;;
+        help|--help|-h)
+            show_usage
+            ;;
+        *)
+            log_error "Unknown command: ${1:-}"
+            show_usage
+            exit 1
+            ;;
+    esac
+}
+
+# Run main function
+main "$@"


### PR DESCRIPTION
This pull request introduces a Fedora-based bootable container image for deploying a TeamSpeak 3 server using bootc technology. It adds all necessary configuration files, systemd service definitions, and documentation to automate the build and deployment process, including SSH key management and persistent data handling. The changes focus on enabling rapid, automated deployment of a secure and updatable TeamSpeak server with persistent storage and hardened service configuration.

**Container image and deployment automation**

* Added `Containerfile` to build a Fedora bootc container image with TeamSpeak 3.13.7, systemd integration, persistent data directories, system user setup, and service configuration for automated deployment.
* Introduced `config/config.toml` with Anaconda kickstart configuration for automated ISO installation, user and SSH key injection, and persistent filesystem setup for TeamSpeak data.

**Service configuration and security**

* Added `config/teamspeak.service` systemd unit file with security hardening, persistent writable paths, and pre-start directory ownership checks for compatibility with bootc and reliable service startup.
* Included `config/ts3server.ini` with TeamSpeak server configuration, persistent paths, networking, and security settings for robust server operation.

**Documentation and management**

* Overhauled `README.md` to provide detailed instructions, architecture overview, deployment steps, and Proxmox VM creation guidance for end-to-end TeamSpeak server deployment using bootc.
* Added `keys/README.md` documenting SSH key management, access instructions, and regeneration workflow via the management script.