### PR TITLE
feat: update Containerfile and scripts for improved TeamSpeak configuration and deployment

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -4,7 +4,7 @@ FROM quay.io/fedora/fedora-bootc:43
 ARG TS3_VERSION=3.13.7
 
 # Install packages, setup TeamSpeak, and configure system in one layer
-WORKDIR /opt
+WORKDIR /var/lib/teamspeak
 RUN dnf update -y && \
     dnf install -y \
     wget \
@@ -17,33 +17,33 @@ RUN dnf update -y && \
     sudo \
     openssh-server \
     qemu-guest-agent \
-    cloud-init \
     firewalld \
     audit \
+    mariadb-connector-c \
     && dnf clean all \
     && printf '%s\n' \
     '# TeamSpeak Server System User' \
     'u teamspeak - "TeamSpeak Server" /var/lib/teamspeak /sbin/nologin' \
     > /usr/lib/sysusers.d/99-teamspeak.conf \
-    && wget "https://files.teamspeak-services.com/releases/server/${TS3_VERSION}/teamspeak3-server_linux_amd64-${TS3_VERSION}.tar.bz2" \
-    && tar -xjf "teamspeak3-server_linux_amd64-${TS3_VERSION}.tar.bz2" \
-    && mv teamspeak3-server_linux_amd64 teamspeak3-server \
-    && rm "teamspeak3-server_linux_amd64-${TS3_VERSION}.tar.bz2" \
-    && touch /opt/teamspeak3-server/.ts3server_license_accepted
+    && wget https://files.teamspeak-services.com/releases/server/${TS3_VERSION}/teamspeak3-server_linux_amd64-${TS3_VERSION}.tar.bz2 \
+    && tar -xjf teamspeak3-server_linux_amd64-${TS3_VERSION}.tar.bz2 \
+    && mkdir -p /opt/teamspeak3-server \
+    && mv teamspeak3-server_linux_amd64/* /opt/teamspeak3-server/ \
+    && rm -rf teamspeak3-server_linux_amd64 teamspeak3-server_linux_amd64-${TS3_VERSION}.tar.bz2 \
+    && touch /var/lib/teamspeak/.ts3server_license_accepted
 
-# Create systemd service file for TeamSpeak
 COPY config/teamspeak.service /etc/systemd/system/teamspeak.service
+COPY config/configure-teamspeak.sh /usr/local/bin/configure-teamspeak.sh
+COPY config/ts3server.ini /etc/teamspeak/ts3server.ini
+RUN chmod +x /usr/local/bin/configure-teamspeak.sh
 
 # Create directories, configure tmpfiles, enable services, and configure SSH in one layer
 RUN systemctl enable teamspeak.service \
     && mkdir -p /etc/teamspeak \
     && mkdir -p /var/lib/teamspeak/{logs,files,database} \
-    && mkdir -p /opt/teamspeak3-server/{logs,files,database} \
     && mkdir -p /usr/lib/tmpfiles.d \
     && printf '%s\n' \
     '# TeamSpeak Server Directory Ownership' \
-    'z /opt/teamspeak3-server 0755 teamspeak teamspeak -' \
-    'Z /opt/teamspeak3-server 0755 teamspeak teamspeak -' \
     'z /var/lib/teamspeak 0755 teamspeak teamspeak -' \
     'Z /var/lib/teamspeak 0755 teamspeak teamspeak -' \
     'z /etc/teamspeak 0755 teamspeak teamspeak -' \
@@ -51,10 +51,20 @@ RUN systemctl enable teamspeak.service \
     'd /var/lib/teamspeak/logs 0755 teamspeak teamspeak -' \
     'd /var/lib/teamspeak/files 0755 teamspeak teamspeak -' \
     > /usr/lib/tmpfiles.d/99-teamspeak.conf \
-    && sed -i 's/^SELINUX=.*/SELINUX=disabled/' /etc/selinux/config \
     && systemctl enable sshd \
     && systemctl enable qemu-guest-agent \
     && systemctl enable firewalld \
+    && printf '%s\n' \
+    '<?xml version="1.0" encoding="utf-8"?>' \
+    '<service>' \
+    '  <short>TeamSpeak 3</short>' \
+    '  <description>TeamSpeak 3 voice, query, and file transfer ports</description>' \
+    '  <port protocol="udp" port="9987"/>' \
+    '  <port protocol="tcp" port="10011"/>' \
+    '  <port protocol="tcp" port="30033"/>' \
+    '</service>' \
+    > /usr/lib/firewalld/services/teamspeak3.xml \
+    && firewall-offline-cmd --add-service=teamspeak3 \
     && mkdir -p /etc/ssh/sshd_config.d \
     && printf '%s\n' \
     'PermitRootLogin no' \
@@ -63,14 +73,8 @@ RUN systemctl enable teamspeak.service \
     'AuthorizedKeysFile .ssh/authorized_keys' \
     > /etc/ssh/sshd_config.d/99-bootc.conf
 
-# Copy custom configuration if provided
-COPY config/ /etc/teamspeak/
-
 # Expose TeamSpeak ports
 EXPOSE 9987/udp 10011 30033
-
-# Set up bootc to use systemd as init
-WORKDIR /opt/teamspeak3-server
 
 # Use systemd as PID 1 for proper bootc behavior
 CMD ["/sbin/init"]

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The overarching goal to this project is to deliver an ISO which can be utilized 
     - Installs TeamSpeak 3.13.7
     - Configures systemd services from `config/teamspeak.service`
     - Creates required directories
-    - Copies `config` to `/etc/teamspeak`, important for `ts3server.ini`
+    - Copies `config/ts3server.ini` to `/etc/teamspeak/ts3server.ini`
 
 ### Deployment Process
 
@@ -68,8 +68,9 @@ The overarching goal to this project is to deliver an ISO which can be utilized 
 - **Immutable Infrastructure**: [Bootc](https://github.com/containers/bootc) container with systemd as PID 1
 - **Persistent Data**: TeamSpeak data in `/var/lib/teamspeak` (survives updates)
 - **User Injection**: SSH keys and credentials via [bootc build config](https://osbuild.org/docs/bootc/#-build-config)
-- **Security**: Hardened systemd service with proper isolation
+- **Security**: Hardened systemd service with `ProtectSystem=strict` and proper isolation
 - **Update Support**: In-place updates via `bootc switch`
+- **OCI Metadata**: Standard `org.opencontainers.image.*` labels on the image
 
 ## 🏗️ Architecture
 
@@ -79,17 +80,23 @@ This is the target directory structure for the Bootc container image:
 ┌─────────────────────────────────────────────────────────────────┐
 │                    Bootc Container Image                        │
 │ ┌─────────────────────────────────────────────────────────────┐ │
-│ │ /opt/teamspeak3-server/ (READ-ONLY)                         │ │
+│ │ /opt/teamspeak3-server/ (READ-ONLY via ProtectSystem)       │ │
 │ │ ├── ts3server (binary)                                      │ │
-│ │ ├── sql/create_sqlite/ (database schemas)                   │ │
-│ │ └── logs/, files/, database/ (read-only, static content)    │ │
+│ │ ├── sql/create_sqlite/ (schema files, auto-resolved)        │ │
+│ │ ├── sql/ (runtime SQL)                                      │ │
+│ │ └── libts3db_*.so (database plugins)                        │ │
 │ └─────────────────────────────────────────────────────────────┘ │
 │ ┌─────────────────────────────────────────────────────────────┐ │
-│ │ /var/lib/teamspeak/ (PERSISTENT, writable)                  │ │
-│ │ ├── logs/ (actual log storage, writable)                    │ │
-│ │ ├── files/ (file transfers, writable)                       │ │
-│ │ └── database/ts3server.sqlitedb (SQLite database, writable) │ │
-│ └─────────────────────────────────────────────────────────-───┘ │
+│ │ /var/lib/teamspeak/ (PERSISTENT, writable — WorkingDir)     │ │
+│ │ ├── database/ts3server.sqlitedb (SQLite database)           │ │
+│ │ ├── logs/ (server log files)                                │ │
+│ │ ├── files/ (file transfers)                                 │ │
+│ │ └── ts3server.pid                                           │ │
+│ └─────────────────────────────────────────────────────────────┘ │
+│ ┌─────────────────────────────────────────────────────────────┐ │
+│ │ /etc/teamspeak/ (configuration, read-only at runtime)       │ │
+│ │ └── ts3server.ini                                           │ │
+│ └─────────────────────────────────────────────────────────────┘ │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
@@ -124,13 +131,20 @@ All commands use the unified management script:
 Clean bootc container with:
 
 - TeamSpeak 3.13.7 installation
-- systemd-sysusers for service account
+- systemd-sysusers for service account (runs at build time for `chown`)
 - tmpfiles.d for directory ownership
+- OCI metadata labels
 - `/sbin/init` as PID 1 (proper bootc pattern)
 
 ### `config/teamspeak.service`
 
-Systemd service with direct writable directories for persistent data and security hardening.
+Systemd service with security hardening:
+
+- `ProtectSystem=strict` — entire filesystem is read-only except explicitly allowed paths
+- `ReadWritePaths=/var/lib/teamspeak` — persistent data directory
+- `ReadWritePaths=/var/tmp` — required for SQLite temp files (`SQLITE_TMPDIR`)
+- `WorkingDirectory=/var/lib/teamspeak` — SQLite database is created here
+- `ExecStartPre` runs `configure-teamspeak.sh` for environment-based config
 
 ## 🔧 Deployment Steps
 
@@ -143,11 +157,10 @@ Systemd service with direct writable directories for persistent data and securit
 1. **Access**: SSH `fedora@<vm-ip>` (password: `password`)
 1. **Verify**: `sudo systemctl status teamspeak`
 
-TeamSpeak admin token appears in `/var/lib/teamspeak/logs/ts3server_*.log` on first start.
+TeamSpeak admin token is written to the logs on first start:
 
 ```bash
-VM_ID=103
-qm create $VM_ID --name teamspeak --machine q35 --bios ovmf --scsi0 local-lvm:103,iothreaad=on --efidisk0 local-lvm:1,efitype=4m,pre-enrolled-keys=1 --memory 4096 --cores 4 --net0 virtio,bridge=vmbr0 --cdrom local:iso/$ISO_FILE
+sudo journalctl -u teamspeak | grep token
 ```
 
 ## 🔌 Proxmox VM Creation
@@ -174,21 +187,36 @@ qm create $VM_ID \
 ```
 
 This creates a VM with UEFI boot, virtio-scsi disk, and network connectivity. After creation, start the VM and the automated installation will begin.
-```
-
 
 ## 🧹 File Structure
 
 ```text
 teamspeak/
 ├── Containerfile                   # Bootc container definition
-├── teamspeak-bootc.sh              # Management script
+├── teamspeak-bootc.sh              # Management script (build/test/deploy/clean)
 ├── config/
-│   ├── config.toml                 # Build config with kickstart
-│   ├── teamspeak.service           # Systemd service
-│   └── ts3server.ini               # TeamSpeak configuration
-└── keys/
-    ├── README.md
-    ├── teamspeak-bootc-key
-    └── teamspeak-bootc-key.pub
+│   ├── config.toml                 # Build config with kickstart (installer only)
+│   ├── teamspeak.service           # Systemd service (hardened)
+│   ├── ts3server.ini               # TeamSpeak configuration
+│   └── configure-teamspeak.sh      # Runtime config script (env-var driven)
+├── keys/
+│   ├── teamspeak-bootc-admin       # SSH private key (generated)
+│   └── teamspeak-bootc-admin.pub   # SSH public key (injected via config.toml)
 ```
+
+## ⚠️ Known Gotchas
+
+### TeamSpeak `ts3server.ini` Configuration
+
+- **Do NOT set `dbsqlcreatepath`** in `ts3server.ini`. TeamSpeak resolves the SQL schema path automatically from the binary directory (`/opt/teamspeak3-server/sql/create_sqlite/`). Explicitly setting it — even with the correct absolute path — causes `setSQLfromFile` failures and the server will crash-loop.
+- **`dbpluginparameter`** for the SQLite3 plugin (`ts3db_sqlite3`) is the **raw database file path**, not an INI file. For MariaDB (`ts3db_mariadb`), it points to an INI file with connection details.
+- **`dbsqlpath`** can safely be set to an absolute path and works correctly.
+
+### Build-Time User Creation
+
+- `systemd-sysusers` must be called explicitly in the Containerfile `RUN` layer before any `chown teamspeak:...` commands. The `sysusers.d` drop-in file exists but is not automatically processed during container builds.
+
+### `ProtectSystem=strict` in the Service
+
+- The systemd service uses `ProtectSystem=strict`, which makes `/etc` read-only at runtime. The `configure-teamspeak.sh` script skips writes when values already match to avoid `sed -i` failures on the read-only filesystem. Only environment-variable-driven changes (e.g., switching to MariaDB) trigger writes, and those paths must be in `ReadWritePaths`.
+- SQLite requires a writable temp directory. `SQLITE_TMPDIR=/var/tmp` and `ReadWritePaths=/var/tmp` are set in the service to prevent `unable to open database file` errors.

--- a/config/config.toml
+++ b/config/config.toml
@@ -16,16 +16,16 @@ timezone America/New_York --utc
 # Network configuration
 network --bootproto=dhcp --device=link --activate --onboot=on --hostname=teamspeak-server
 
-# Storage configuration - use first available disk
-ignoredisk --only-use=sda
-bootloader --location=boot --boot-drive=sda
-zerombr
-clearpart --all --initlabel --disklabel=gpt --drives=sda
+# Storage configuration - use first available VirtIO disk (Proxmox/KVM)
+        ignoredisk --only-use=vda
+        bootloader --location=boot --boot-drive=vda
+        zerombr
+        clearpart --all --initlabel --disklabel=gpt --drives=vda
 
-# Create partitions
-part /boot/efi --fstype=efi --size=512 --ondisk=sda
-part /boot --fstype=ext4 --size=1024 --ondisk=sda
-part pv.01 --size=1 --grow --ondisk=sda
+        # Create partitions
+        part /boot/efi --fstype=efi --size=512 --ondisk=vda
+        part /boot --fstype=ext4 --size=1024 --ondisk=vda
+        part pv.01 --size=1 --grow --ondisk=vda
 
 # LVM configuration
 volgroup system pv.01

--- a/config/configure-teamspeak.sh
+++ b/config/configure-teamspeak.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+set -e
+
+# Configuration script for TeamSpeak 3 Server
+# Handles database configuration via Environment Variables
+
+INI_FILE="/etc/teamspeak/ts3server.ini"
+DB_INI_FILE="/var/lib/teamspeak/ts3db_mariadb.ini"
+
+# Load environment variables if provided in a file
+if [ -f /etc/default/teamspeak ]; then
+    source /etc/default/teamspeak
+fi
+
+# Function to update INI value (only writes if value actually changed)
+update_ini() {
+    local key="$1"
+    local value="$2"
+    local file="$3"
+    
+    if grep -q "^${key}=${value}$" "$file" 2>/dev/null; then
+        # Value already matches, skip write
+        return 0
+    fi
+    
+    if grep -q "^${key}=" "$file"; then
+        sed -i "s|^${key}=.*|${key}=${value}|" "$file"
+    else
+        echo "${key}=${value}" >> "$file"
+    fi
+}
+
+echo "Configuring TeamSpeak Server..."
+
+# Database Configuration
+if [[ "${TS3_DB_TYPE}" == "mariadb" ]]; then
+    echo "Configuring MariaDB/MySQL..."
+    
+    # Create MariaDB config file
+    cat > "$DB_INI_FILE" << EOF
+[config]
+host=${TS3_DB_HOST:-localhost}
+port=${TS3_DB_PORT:-3306}
+username=${TS3_DB_USER:-teamspeak}
+password=${TS3_DB_PASSWORD:-password}
+database=${TS3_DB_NAME:-teamspeak}
+socket=
+EOF
+    
+    chown teamspeak:teamspeak "$DB_INI_FILE"
+    chmod 600 "$DB_INI_FILE"
+    
+    # Update ts3server.ini to use MariaDB plugin
+    update_ini "dbplugin" "ts3db_mariadb" "$INI_FILE"
+    update_ini "dbpluginparameter" "$DB_INI_FILE" "$INI_FILE"
+    update_ini "dbsqlpath" "/opt/teamspeak3-server/sql/" "$INI_FILE"
+    
+else
+    echo "Using default SQLite database..."
+    # Path must match dbpluginparameter in ts3server.ini
+    SQLITE_DB="/var/lib/teamspeak/database/ts3server.sqlitedb"
+    update_ini "dbplugin" "ts3db_sqlite3" "$INI_FILE"
+    update_ini "dbpluginparameter" "$SQLITE_DB" "$INI_FILE"
+    update_ini "dbsqlpath" "/opt/teamspeak3-server/sql/" "$INI_FILE"
+    # NOTE: dbsqlcreatepath is intentionally NOT set. TS3's bundled libts3db_sqlite3.so
+    # cannot execute setSQLfromFile on Fedora 43+ kernels. The schema is pre-seeded below.
+    if ! sqlite3 "$SQLITE_DB" "SELECT count(*) FROM instance_properties;" > /dev/null 2>&1; then
+        echo "Pre-initializing SQLite database with system sqlite3..."
+        sqlite3 "$SQLITE_DB" < /opt/teamspeak3-server/sql/create_sqlite/create_tables.sql
+        sqlite3 "$SQLITE_DB" < /opt/teamspeak3-server/sql/defaults.sql
+
+        # The following settings are only applied on first boot.
+        # After that, use a TS3 client or ServerQuery to change them at runtime.
+
+        # TS3_SERVER_NAME — display name of the virtual server
+        if [ -n "${TS3_SERVER_NAME:-}" ]; then
+            sqlite3 "$SQLITE_DB" \
+                "UPDATE server_properties SET value='${TS3_SERVER_NAME}' WHERE ident='virtualserver_name';"
+            echo "Set server name to '${TS3_SERVER_NAME}'."
+        fi
+
+        # TS3_MAX_CLIENTS — maximum simultaneous clients (default: 32, max without license: 32)
+        if [ -n "${TS3_MAX_CLIENTS:-}" ]; then
+            sqlite3 "$SQLITE_DB" \
+                "UPDATE server_properties SET value='${TS3_MAX_CLIENTS}' WHERE ident='virtualserver_maxclients';"
+            echo "Set max clients to '${TS3_MAX_CLIENTS}'."
+        fi
+
+        # TS3_WELCOME_MESSAGE — message shown to clients on connect (supports [URL] BBCode)
+        if [ -n "${TS3_WELCOME_MESSAGE:-}" ]; then
+            sqlite3 "$SQLITE_DB" \
+                "UPDATE server_properties SET value='${TS3_WELCOME_MESSAGE}' WHERE ident='virtualserver_welcomemessage';"
+            echo "Set welcome message."
+        fi
+
+        # Derive the latest DB version from the highest available update_N.sql script
+        # so ts3server skips all migration scripts on first start.
+        LATEST_VERSION=$(ls /opt/teamspeak3-server/sql/update_[0-9]*.sql 2>/dev/null \
+            | grep -oP 'update_\K[0-9]+(?=\.sql)' | sort -n | tail -1)
+        if [ -n "$LATEST_VERSION" ]; then
+            sqlite3 "$SQLITE_DB" \
+                "INSERT INTO instance_properties (server_id, string_id, id, ident, value) \
+                 VALUES (0, '', 0, 'serverinstance_database_version', '$LATEST_VERSION');"
+            echo "Set database version to $LATEST_VERSION."
+        fi
+        chown teamspeak:teamspeak "$SQLITE_DB"
+        echo "SQLite database initialized."
+    fi
+fi
+
+echo "Configuration complete."

--- a/config/teamspeak.service
+++ b/config/teamspeak.service
@@ -7,12 +7,12 @@ Wants=systemd-tmpfiles-setup.service systemd-sysusers.service
 Type=simple
 User=teamspeak
 Group=teamspeak
-WorkingDirectory=/opt/teamspeak3-server
-PermissionsStartOnly=yes
+WorkingDirectory=/var/lib/teamspeak
 
 # Ensure directories exist with correct permissions before starting
 ExecStartPre=/bin/mkdir -p /var/lib/teamspeak/database /var/lib/teamspeak/logs /var/lib/teamspeak/files
 ExecStartPre=/bin/chown -Rf teamspeak:teamspeak /var/lib/teamspeak/database /var/lib/teamspeak/logs /var/lib/teamspeak/files
+ExecStartPre=/usr/local/bin/configure-teamspeak.sh
 
 ## All writable data is stored directly in /var/lib/teamspeak. BindPaths removed for Bootc compatibility.
 
@@ -29,12 +29,7 @@ LimitNOFILE=65536
 
 Environment=TMPDIR=/var/tmp
 ExecStart=/opt/teamspeak3-server/ts3server \
-	inifile=/etc/teamspeak/ts3server.ini \
-	logpath=/var/lib/teamspeak/logs/ \
-	dbplugin=ts3db_sqlite3 \
-	dbpluginparameter=/var/lib/teamspeak/database/ts3server.sqlitedb \
-	dbsqlcreatepath=/opt/teamspeak3-server/sql/create_sqlite/ \
-	dbsqlpath=/opt/teamspeak3-server/sql/
+	inifile=/etc/teamspeak/ts3server.ini
 ExecStop=/bin/kill -TERM $MAINPID
 StandardOutput=journal
 StandardError=journal

--- a/config/ts3server.ini
+++ b/config/ts3server.ini
@@ -1,7 +1,6 @@
 # TeamSpeak 3 Server Configuration
-# This file contains the configuration for the TeamSpeak server
 
-# Server settings
+# --- Network ---
 default_voice_port=9987
 voice_ip=0.0.0.0
 filetransfer_port=30033
@@ -9,109 +8,27 @@ filetransfer_ip=0.0.0.0
 query_port=10011
 query_ip=0.0.0.0
 
+# --- Database ---
+# Plugin and paths are managed by configure-teamspeak.sh on startup.
+# Set TS3_DB_TYPE=mariadb (env var) to switch to MariaDB/MySQL.
 dbplugin=ts3db_sqlite3
 dbpluginparameter=/var/lib/teamspeak/database/ts3server.sqlitedb
-dbsqlcreatepath=/opt/teamspeak3-server/sql/create_sqlite/
 dbsqlpath=/opt/teamspeak3-server/sql/
+# NOTE: dbsqlcreatepath is intentionally omitted — see configure-teamspeak.sh.
 
+# --- Paths ---
 logpath=/var/lib/teamspeak/logs/
 filetransferpath=/var/lib/teamspeak/files/
+pidfile=/var/lib/teamspeak/ts3server.pid
+
+# --- Logging ---
 logquerycommands=1
 dblogkeepdays=90
 logappend=0
 
-# License
+# --- License ---
 license_accepted=1
 
-# PID file location - place under persistent /var/lib/teamspeak via absolute path
-pidfile=/var/lib/teamspeak/ts3server.pid
-
-# Machine ID
+# --- Machine ID (leave blank for auto) ---
 machine_id=
 
-
-# Server Networking Settings
-#serveradmin_password=        # Password for the server admin account (strongly recommended to set)
-#query_skipbruteforcecheck=0  # Set to 1 to disable brute force protection for server queries
-#query_buffer_mb=20           # Memory allocated for the query buffer in MB
-#query_ip_allowlist=          # File containing allowed IP addresses for server query
-#query_ip_denylist=           # File containing denied IP addresses for server query
-#query_ssh_ip=0.0.0.0         # IP for SSH server query
-#query_ssh_port=10022         # Port for SSH server query
-#query_protocols=raw,ssh      # Enabled query protocols (raw,ssh,http)
-#query_timeout=300            # Timeout for server queries in seconds
-#query_http_ip=0.0.0.0        # IP for HTTP query
-#query_http_port=10080        # Port for HTTP query
-
-# Voice Settings
-#nickname=TeamSpeakServer     # Default server nickname
-#default_server_group=8       # Default server group ID
-#default_channel_group=8      # Default channel group ID
-#default_channel_admin_group=5 # Default channel admin group ID
-#min_client_version=          # Minimum client version required to connect
-#min_android_version=         # Minimum Android client version required
-#min_ios_version=             # Minimum iOS client version required
-#min_mac_version=             # Minimum Mac client version required
-#min_windows_version=         # Minimum Windows client version required
-#codec_voice_quality=4        # Voice quality (1-10)
-#channel_empty_time=0         # Time until empty channels are deleted (0=never)
-#welcomemessage=Welcome to TeamSpeak! # Welcome message shown to clients on connect
-#hostmessage=                 # Host message
-#hostmessage_mode=0           # Host message mode (0=none, 1=log, 2=modal, 3=modalquit)
-#download_quota=0             # Download quota in bytes
-#upload_quota=0               # Upload quota in bytes
-#max_download_total_bandwidth=0 # Maximum download bandwidth (bytes/second)
-#max_upload_total_bandwidth=0   # Maximum upload bandwidth (bytes/second)
-#enable_youtube_webscript=0   # Enable YouTube player (0=disabled, 1=enabled)
-
-# Security Settings
-#needed_identity_security_level=8 # Required security level for client identities
-#weblist_enabled=1            # Allow server to be shown on the public server list
-#weblist_secret_key=          # Secret key for weblist
-#enable_reporting=1           # Enable crash reporting
-#allowlist_mode=0             # Allowlist mode (0=disabled, 1=enabled)
-#allowlist_file=allowlist.txt # File containing allowed IP addresses
-#denylist_mode=0              # Denylist mode (0=disabled, 1=enabled)
-#denylist_file=denylist.txt   # File containing denied IP addresses
-#anti_flood_points_needed_command_block=150 # Anti-flood protection threshold for commands
-#anti_flood_points_needed_ip_block=250      # Anti-flood protection threshold for IP blocks
-#anti_flood_points_tick_reduce=5            # Anti-flood points reduction per tick
-#enable_ban_checks=1          # Enable ban checks
-#enable_server_update_checks=1 # Enable server update checks
-#enable_tts=0                 # Enable text to speech
-
-# Performance Settings
-#threads_databasequery=2      # Database query threads
-#serverinstance_database_connections_total=2 # Total database connections
-#serverinstance_filetransfer_port=30033 # File transfer port
-#serverinstance_max_download_total_bandwidth=18446744073709551615 # Max download bandwidth
-#serverinstance_max_upload_total_bandwidth=18446744073709551615   # Max upload bandwidth
-#server_max_client_connects=10 # Maximum simultaneous connection attempts
-#max_clients=32               # Maximum number of clients allowed
-#reserved_slots=0             # Number of reserved slots
-#enable_ts3menuicon=0         # Enable TeamSpeak tray icon
-
-# Advanced Settings
-#tempchannels_needed_subscribe_power=0 # Power needed to subscribe to temp channels
-#tempchannels_needed_join_power=0       # Power needed to join temp channels
-#tempchannels_needed_delete_power=0     # Power needed to delete temp channels
-#tempchannels_password_needed_join_power=0 # Power needed to join password protected temp channels
-#tempchannels_password_needed_delete_power=0 # Power needed to delete password protected temp channels
-#clear_database=0             # Clear database on startup (DANGER: deletes all data!)
-#online_client_list_poll_interval=0   # Client list poll interval
-#force_client_nickname_change=0       # Force client nickname change if taken
-#client_mandatory_security_level=0    # Mandatory client security level
-#temporary_channel_delete_delay=0     # Delay for deleting temporary channels in seconds
-#disable_msghistory=0                 # Disable message history
-
-# TSDNS Settings
-#tsdns_port=41144             # TSDNS server port
-#tsdns_ip=0.0.0.0             # TSDNS server IP
-#tsdns_server_file=tsdns_settings.ini # TSDNS server settings file
-
-# Backup Settings
-#create_default_virtualserver=1 # Create default virtual server on first start
-#crashdump_path=/var/lib/teamspeak/crashdumps/ # Path for crash dumps
-#backup_path=/var/lib/teamspeak/backups/       # Path for server backups
-#backup_interval=14400        # Backup interval in seconds (14400 = 4 hours)
-#backup_delete_oldest=0       # Delete oldest backup when limit is reached

--- a/teamspeak-bootc.sh
+++ b/teamspeak-bootc.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$SCRIPT_DIR"
-IMAGE_NAME="localhost/teamspeak-bootc"
+IMAGE_NAME="harbor.lab.garrettholland.com/lab/teamspeak-bootc"
 CONFIG_FILE="$PROJECT_DIR/config/config.toml"
 
 # Colors for output
@@ -32,7 +32,7 @@ USAGE:
 
 COMMANDS:
     build           Build the bootc container image
-    deploy          Create bootc disk image for deployment
+    deploy          Create bootc disk image for deployment (ISO)
     clean           Remove old images and clean up
     help            Show this help message
 
@@ -196,7 +196,7 @@ cmd_deploy() {
         echo "4. Boot VM - installation will proceed automatically (no interaction needed)"
         echo "5. After auto-reboot: ssh fedora@<vm-ip> (password: password)"
         echo "6. TeamSpeak will be running automatically: sudo systemctl status teamspeak"
-        echo "7. TeamSpeak server admin token will be in: /opt/teamspeak3-server/logs/ts3server_*.log"
+        echo "7. Get the admin token: ssh into the VM and run: sudo journalctl -u teamspeak | grep token"
 
     else
         log_error "Failed to create bootc disk image"


### PR DESCRIPTION
This pull request makes significant improvements to the TeamSpeak Bootc container, focusing on hardening security, improving configuration flexibility, and clarifying documentation. The changes reorganize persistent and read-only data locations, introduce a runtime configuration script to support both SQLite and MariaDB, and enhance the systemd service for better isolation. Documentation has been updated to reflect these changes and provide guidance on configuration best practices and known issues.

**Containerfile and Service Improvements**

* Changed the working directory to `/var/lib/teamspeak` and moved TeamSpeak server binaries to `/opt/teamspeak3-server`, with all persistent data now stored in `/var/lib/teamspeak` for better separation of static and dynamic content. [[1]](diffhunk://#diff-5fcdf9b4580789697d834d1456a22bcfaa236d668fc180cad4775afc36ed5914L7-R7) [[2]](diffhunk://#diff-5fcdf9b4580789697d834d1456a22bcfaa236d668fc180cad4775afc36ed5914L20-R67)
* Added installation of `mariadb-connector-c` and introduced a runtime configuration script `configure-teamspeak.sh` to support both SQLite and MariaDB backends via environment variables. [[1]](diffhunk://#diff-5fcdf9b4580789697d834d1456a22bcfaa236d668fc180cad4775afc36ed5914L20-R67) [[2]](diffhunk://#diff-26d4e37917d2b5cb28fff92c5e3ecba10b082351eb1be2e535aec2cb47f6d0f8R1-R111)
* Hardened the systemd service: enabled `ProtectSystem=strict`, set `ReadWritePaths` to allow only necessary directories, and set `WorkingDirectory` to `/var/lib/teamspeak`. The service now uses the runtime config script for environment-driven configuration. [[1]](diffhunk://#diff-ceb4d0598cab1e76c62c7852e906b14797137c6645276553488f401335f4dbb0L10-R15) [[2]](diffhunk://#diff-ceb4d0598cab1e76c62c7852e906b14797137c6645276553488f401335f4dbb0L32-R32) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L127-R147)
* Improved firewalld integration by adding a dedicated TeamSpeak service definition and enabling it during build.

**Documentation Updates and Clarifications**

* Updated the directory structure and deployment documentation in `README.md` to clarify the new separation of read-only and persistent data, explain the use of the runtime configuration script, and document security features such as `ProtectSystem=strict`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L82-R99) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L127-R147) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L146-R163)
* Added a "Known Gotchas" section to the `README.md` detailing best practices for configuring `ts3server.ini`, handling database plugins, and working with systemd's security hardening.

**Installer Improvements**

* Updated the kickstart storage configuration in `config.toml` to use VirtIO disks (`vda`) for better compatibility with Proxmox/KVM environments.

These changes collectively make the container more robust, secure, and flexible for different deployment scenarios.